### PR TITLE
fix: 버튼 디바이스 하단 고정

### DIFF
--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -56,7 +56,8 @@
 .footer {
   position: fixed;
   bottom: 0;
-  left: 0;
-  right: 0;
+  width: 100%;
+  min-width: 320px;
+  max-width: 500px;
   height: 4rem;
 }


### PR DESCRIPTION
‘만들기’ 버튼, ‘이전, 0장의 사진 등록, 완료’ 버튼 디바이스 하단 고정